### PR TITLE
feat: pass in existing context to the merge function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ async function someOtherFunc(
 
 - `new AsyncContext<T>(context?: T | (() => T | Promise<T>))`: Create a new async context object.
 - `AsyncContext#set(context: T | (() => T | Promise<T>)`: Set context value. This is used when the context is created the producer while `set()` is called by consumer.
-- `AsyncContext#merge(context: T | (() => T | Promise<T>)`: Merge new context input to create a new async context object.
+- `AsyncContext#merge(context: T | ((currentContext) => T | Promise<T>)`: Merge new context input to create a new async context object.
 - `AsyncContext#clear()`: Clear the context as if the context is created with no context argument during creation or with `set()` method calls. Used mostly for testing.
 
 [codacy-image]: https://api.codacy.com/project/badge/Grade/569e678c65cf4481a172aaeb83b41aef

--- a/src/AsyncContext.spec.ts
+++ b/src/AsyncContext.spec.ts
@@ -156,6 +156,16 @@ test('merge change types of existing property', async () => {
 
   const result = await ctx.get()
 
-  assertType<'a'|'b'>(result.type)
+  assertType<'a' | 'b'>(result.type)
   assertType.isNumber(result.value)
+})
+
+test('merge function receives current context for more better merge function reuse', async () => {
+  type Orig = { type: 'a' | 'b', value: number }
+
+  const orig = new AsyncContext<Orig>({ type: 'a', value: 1 })
+  const transform = async (context: AsyncContext<Orig>) => ({ value: String(await (await context.get()).value) })
+
+  const merged = orig.merge(transform)
+  expect(await merged.get()).toEqual({ type: 'a', value: '1' })
 })

--- a/src/AsyncContext.ts
+++ b/src/AsyncContext.ts
@@ -32,8 +32,8 @@ export class AsyncContext<T extends Record<string | symbol, any>> {
   clear() {
     this.ready = new Promise<T>(a => this.resolve = a)
   }
-  merge<R extends Record<string | symbol, any>>(context: R | (() => R | Promise<R>), options?: Partial<AsyncContext.Options>): AsyncContext<LeftJoin<T,R>> {
-    return new AsyncContext(async () => ({ ...await this.get(), ...await resolveContext(context) }), options)
+  merge<R extends Record<string | symbol, any>>(context: R | ((context: AsyncContext<T>) => R | Promise<R>), options?: Partial<AsyncContext.Options>): AsyncContext<LeftJoin<T,R>> {
+    return new AsyncContext(async () => ({ ...await this.get(), ...await resolveContext(context, this) }), options)
   }
 }
 
@@ -46,6 +46,6 @@ export namespace AsyncContext {
   }
 }
 
-function resolveContext<T extends Record<string | symbol, any>>(context: T | (() => T | Promise<T>)) {
-  return typeof context === 'function' ? (context as any)() : context
+function resolveContext<T extends Record<string | symbol, any>, R extends Record<string | symbol, any>>(context: R | ((context: AsyncContext<T>) => R | Promise<R>), currentContext?: AsyncContext<T>) {
+  return typeof context === 'function' ? (context as any)(currentContext) : context
 }


### PR DESCRIPTION
this allows the merge function to be declared elsewhere and reuse in multiple places,
without messing with scopes